### PR TITLE
 Can now move model and view using widgets.

### DIFF
--- a/resources/shaders/basic.fragment.glsl
+++ b/resources/shaders/basic.fragment.glsl
@@ -1,7 +1,8 @@
 #version 330 core
 
-in vec3  color;
 out vec3 out_color;
+
+uniform vec3 color;
 
 void main()
 {

--- a/resources/shaders/basic.vertex.glsl
+++ b/resources/shaders/basic.vertex.glsl
@@ -2,10 +2,12 @@
 
 in vec3 position;
 
-out vec3 color;
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+
 
 void main()
 {
-    color = position;
-    gl_Position = vec4(position / 5.0, 1.0);
+    gl_Position = projection * view * model * vec4(position, 1.0f);
 }


### PR DESCRIPTION
Fixes #40 
Two new widgets, "model" and "view", were added, which allow the user to manipulate the model's transform and the view's transform. The options on the view could be improved though, as the user is only able to change its position and x/y-direction (where the view looks at). Added new uniforms to the shader, which are updated and uploaded in the game loop. This will need to be refactored.