### PR TITLE
Building gtest with static crt

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,16 @@
+﻿{
+  // See https://go.microsoft.com//fwlink//?linkid=834763 for more information about this file.
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": ""
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #93

Changed gtest to compile with static crt. Also added 'CMakeSettings.json' in .gitignore since Visual Studio seems to want to generate it.