### PR TITLE
Building gtest with static crt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ cmake-build-debug/
 *.stamp*
 *.pc*
 *.tcl*
+CMakeSettings.json
 
 # Prerequisites
 *.d

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ target_include_directories(Nax PRIVATE libraries/imgui/)
 
 # ---- Tests ----
 enable_testing()
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 set(
     TEST_SOURCES    # EXCLUDING MAIN!


### PR DESCRIPTION
Fixes #93

Changed gtest to compile with static crt. Also added 'CMakeSettings.json' in .gitignore since Visual Studio seems to want to generate it.